### PR TITLE
cmake: converge to generic find_package(Avendish) + avnd_addon_* setup

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -1,5 +1,4 @@
 name: Build
-
 on:
   pull_request:
   push:
@@ -11,8 +10,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ossia score addon: dev tree + SDK (latest/continuous) + JIT + tag-gated release,
-  # all four tracks bundled into one reusable workflow (was builds-dev/builds-sdk/jit/release).
-  ci:
+  # Build + package the score add-on (dev / SDK / JIT / release tracks).
+  score:
     uses: ossia/actions/.github/workflows/score-addon.yml@master
     secrets: inherit
+
+  # Build the same object(s) standalone, one artifact per back-end.
+  # CATEGORY object (default, no CATEGORY/BACKENDS declared): data / message
+  # back-ends, no audio plugin formats.
+  standalone:
+    uses: ossia/actions/.github/workflows/avnd-addon.yml@master
+    secrets: inherit
+    with:
+      pd: true
+      max: true
+      python: true
+      touchdesigner: true
+      godot: true
+      wasm: true

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -1,0 +1,19 @@
+name: Portability
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-portability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    uses: ossia/actions/.github/workflows/avnd-portability.yml@master
+    secrets: inherit
+    with:
+      # iOS off: Xcode multi-config plumbing fails and iOS isn't a meaningful
+      # target. The other 20 lanes cover the portability surface.
+      ios: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,84 +1,44 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
-if(NOT TARGET score_lib_base)
-  include(ScoreExternalAddon)
-endif()
-
-if(NOT TARGET score_plugin_avnd)
-  return()
-endif()
-
 project(score_addon_gbap LANGUAGES CXX)
 
-###### GBAP ############
+# Use the Avendish the host (ossia score) provides; otherwise fetch it.
+find_package(Avendish QUIET)
+if(NOT Avendish_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    Avendish
+    GIT_REPOSITORY "https://github.com/celtera/avendish"
+    GIT_TAG main)
+  FetchContent_Populate(Avendish)
+  list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
+  find_package(Avendish REQUIRED)
+endif()
 
-avnd_score_plugin_init(
-  BASE_TARGET score_addon_gbap
-)
+avnd_addon_init(NAME score_addon_gbap)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_gbap
-  SOURCES
-    GBAP/GBAP.hpp
-    GBAP/GBAPModel.hpp
-    GBAP/GBAPModel.cpp
-    GBAP/GridWidget.hpp
-    GBAP/GBAPUi.hpp
-  TARGET GBAP
-  MAIN_CLASS GBAP
-  NAMESPACE spat
-)
+avnd_addon_object(
+  BASE score_addon_gbap C_NAME GBAP CLASS GBAP NAMESPACE spat
+  SOURCES GBAP/GBAP.hpp GBAP/GBAPModel.hpp GBAP/GBAPModel.cpp GBAP/GridWidget.hpp GBAP/GBAPUi.hpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_gbap
-  SOURCES
-    matrix/matrix.hpp
-    matrix/matrixModel.hpp
-    matrix/matrixModel.cpp
-    matrix/matrixUi.hpp
-  TARGET matrix
-  MAIN_CLASS Matrix
-  NAMESPACE spat
-)
+avnd_addon_object(
+  BASE score_addon_gbap C_NAME matrix CLASS Matrix NAMESPACE spat
+  SOURCES matrix/matrix.hpp matrix/matrixModel.hpp matrix/matrixModel.cpp matrix/matrixUi.hpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_gbap
-  SOURCES
-    MultiCursor/MultiCursor.hpp
-    MultiCursor/MultiCursorModel.hpp
-    MultiCursor/MultiCursorModel.cpp
-  TARGET multicursormanager
-  MAIN_CLASS MultiCursorManager
-  NAMESPACE spat
-)
+avnd_addon_object(
+  BASE score_addon_gbap C_NAME multicursormanager CLASS MultiCursorManager NAMESPACE spat
+  SOURCES MultiCursor/MultiCursor.hpp MultiCursor/MultiCursorModel.hpp MultiCursor/MultiCursorModel.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_gbap
-  SOURCES
-    PathGenerator/PathGenerator.hpp
-    PathGenerator/PathGeneratorModel.hpp
-    PathGenerator/PathGeneratorModel.cpp
-  TARGET pathgenerator
-  MAIN_CLASS PathGenerator
-  NAMESPACE spat
-)
+avnd_addon_object(
+  BASE score_addon_gbap C_NAME pathgenerator CLASS PathGenerator NAMESPACE spat
+  SOURCES PathGenerator/PathGenerator.hpp PathGenerator/PathGeneratorModel.hpp PathGenerator/PathGeneratorModel.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_gbap
-  SOURCES
-    Nodes/Nodes.hpp
-    Nodes/NodesModel.hpp
-    Nodes/NodesUi.hpp
-    Nodes/NodesWidget.hpp
-  TARGET Nodes
-  MAIN_CLASS Nodes
-  NAMESPACE  spat
-)
+avnd_addon_object(
+  BASE score_addon_gbap C_NAME Nodes CLASS Nodes NAMESPACE spat
+  SOURCES Nodes/Nodes.hpp Nodes/NodesModel.hpp Nodes/NodesUi.hpp Nodes/NodesWidget.hpp)
 
-avnd_score_plugin_finalize(
-  BASE_TARGET score_addon_gbap
-  PLUGIN_VERSION 1
-  PLUGIN_UUID "1057641E-4253-4BD3-802B-09F063FF559C"
-)
+avnd_addon_finalize(NAME score_addon_gbap UUID 1057641E-4253-4BD3-802B-09F063FF559C VERSION 1)
 
-score_optimize_in_debug_mode(${PROJECT_NAME})
+if(COMMAND score_optimize_in_debug_mode)
+  score_optimize_in_debug_mode(${PROJECT_NAME})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 project(score_addon_gbap LANGUAGES CXX)
 
+# Max/MSP externals link the static CRT (/MT) on Windows, as the official
+# max-sdk-base requires. Set it for the whole addon -- before Avendish and the
+# object library are created -- so every target shares one runtime; mixing /MT
+# and /MD trips MSVC with LNK2038. (CMP0091 is NEW via cmake_minimum_required.)
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 # Use the Avendish the host (ossia score) provides; otherwise fetch it.
 find_package(Avendish QUIET)
 if(NOT Avendish_FOUND)
@@ -9,7 +17,7 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    GIT_TAG main)
+    GIT_TAG 7eafe173)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)


### PR DESCRIPTION
Migrates to the unified Avendish addon CMake (celtera/avendish#97): ScoreExternalAddon bootstrap + avnd_score_plugin_* → find_package(Avendish) (host-aware) + avnd_addon_init/object/finalize for all 5 objects. score_optimize_in_debug_mode guarded by if(COMMAND). Builds in-tree in score; requires score's avendish submodule to include #97 (ossia/score#2075).